### PR TITLE
Update rondo-of-burb.js

### DIFF
--- a/patch/palette/rondo-of-burb.js
+++ b/patch/palette/rondo-of-burb.js
@@ -75,8 +75,8 @@ module.exports = {
 		{ offset: 0x011FF8, bytes: '0F 11 2C 11 0F 15 18 05 0F 14 0B 04 0F 16 20 06' },
 		// Mummy graveyard
 		{ offset: 0x012123, bytes: '0F 04 14 04 0F 15 20 05 0F 15 20 0C 0F 11 20 15' },
-		// Dead end (completely black palette, cruel joke in case anyone ever goes there)
-		{ offset: 0x01202B, bytes: '0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F' },
+		// Dead end (Unused, just listing the offset for future reference)
+		// { offset: 0x01202B, bytes: '0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F 0F' },
 
 		// Endings
 


### PR DESCRIPTION
Commented out the dead end joke, as it turns on paint-it-black mode for that specific screen regardless of flags. And since diamond logic is a thing, this should not be used anymore.